### PR TITLE
fix xattr include names

### DIFF
--- a/logic.c
+++ b/logic.c
@@ -7,7 +7,8 @@
 #include <string.h>
 #include <errno.h>
 #include <unistd.h>
-#include <attr/xattr.h>
+#include <sys/xattr.h>
+#include <attr/attributes.h>
 #include <fts.h>
 #include "logic.h"
 #include "sh.h"

--- a/main.c
+++ b/main.c
@@ -12,8 +12,7 @@
 #include <linux/limits.h>
 #include <stdbool.h>
 #include <sys/stat.h>
-#include <attr/xattr.h>
-#include <linux/stat.h>
+#include <sys/xattr.h>
 #include "logic.h"
 #include "sh.h"
 


### PR DESCRIPTION
Hi,

The master branch does not compile correctly due to an xattr bad Path
Env:
- OS: ArchLinux
- Kernel: Linux 4.19.8

```
➜  overlayfs-tools git:(master) ✗ make
gcc -Wall -std=c99 -c main.c
main.c:15:10: fatal error: attr/xattr.h: No such file or directory
 #include <attr/xattr.h>
          ^~~~~~~~~~~~~~
compilation terminated.
make: *** [makefile:11: main.o] Error 1
```

I create a small branch named **fix_xattr_lib_include** to try to fix this
Now it compiles :
```
➜  overlayfs-tools git:(fix_xattr_lib_include) ✗ make
gcc -Wall -std=c99 -c main.c
gcc -Wall -std=c99 -c logic.c
gcc -lm main.o logic.o sh.o -o overlay
```

I will test a bit more, but feel free to take a look at your side too :)

Bye o/