### PR TITLE
Fixed includes so that it compiles on Ubuntu 20.04

### DIFF
--- a/logic.c
+++ b/logic.c
@@ -7,8 +7,7 @@
 #include <string.h>
 #include <errno.h>
 #include <unistd.h>
-#include <attr/xattr.h>
-#include <attr/attributes.h>
+#include <sys/xattr.h>
 #include <fts.h>
 #include <libgen.h>
 #include "logic.h"

--- a/main.c
+++ b/main.c
@@ -12,7 +12,8 @@
 #include <linux/limits.h>
 #include <stdbool.h>
 #include <sys/stat.h>
-#include <attr/xattr.h>
+#include <sys/xattr.h>
+#include <errno.h>
 #ifndef _SYS_STAT_H
   #include <linux/stat.h>
 #endif


### PR DESCRIPTION
Ubuntu 20.04 seems to have removed certain includes which have already been marked as deprecated for a longer time. This commit upates those include paths and it also contains a missing include statement (errno.h) in one of the files