### PR TITLE
show why files can't be open using errno

### DIFF
--- a/logic.c
+++ b/logic.c
@@ -142,11 +142,11 @@ int regular_file_identical(const char *lower_path, const struct stat *lower_stat
     int lower_file = open(lower_path, O_RDONLY);
     int upper_file = open(upper_path, O_RDONLY);
     if (lower_file < 0) {
-        fprintf(stderr, "File %s can not be read for content.\n", lower_path);
+        fprintf(stderr, "File %s can not be read for content: %s\n", lower_path, strerror(errno));
         return -1;
     }
     if (upper_file < 0) {
-        fprintf(stderr, "File %s can not be read for content.\n", upper_path);
+        fprintf(stderr, "File %s can not be read for content: %s\n", upper_path, strerror(errno));
         return -1;
     }
     ssize_t read_lower; ssize_t read_upper;


### PR DESCRIPTION
Previously:
```
overlay diff -l /mnt/bcachefs.ro -u /mnt/btrfs/bcachefs-overlay/upper -i
File /mnt/bcachefs.ro/home/jerome/.cache/mozilla/firefox/ys68rl1b.home/cache2/entries/BF1822BED286CD3F6AC9379DB217EF5AC572C3F2 can not be read for content.
Action aborted due to fatal error.
```

Now:
```
overlay diff -l /mnt/bcachefs.ro -u /mnt/btrfs/bcachefs-overlay/upper -i
File /mnt/bcachefs.ro/home/.../DB217EF5AC572C3F2 can not be read for content: Too many open files`
Action aborted due to fatal error.
```